### PR TITLE
update to standard@17, migrate to esm, fix tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const createServer = require('./server.js')
+import { createServer } from './server.js'
 
 const server = createServer()
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/standard/standardizer/issues"
   },
+  "type": "module",
   "dependencies": {
     "restify": "^8.6.0",
     "restify-cors-middleware2": "^2.1.2",
@@ -14,7 +15,7 @@
   "devDependencies": {
     "portfinder": "^1.0.28",
     "restify-clients": "^3.1.0",
-    "standard": "^16.0.0",
+    "standard": "^17.0.0",
     "tape": "^5.0.1"
   },
   "engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,7 @@
-const portfinder = require('portfinder')
-
-const clients = require('restify-clients')
-
-const createServer = require('../server.js')
-const test = require('tape')
+import portfinder from 'portfinder'
+import clients from 'restify-clients'
+import { createServer } from '../server.js'
+import test from 'tape'
 
 const server = createServer()
 let client
@@ -35,8 +33,16 @@ test('get version info', (t) => {
 test('lint some text', (t) => {
   client.post('/lint', { text: "console.log('woot');\n" }, (err, req, res, obj) => {
     t.error(err, 'no error')
-    t.equals(obj.errorCount, 1, 'successfully linted')
-    t.equals(obj.results[0].messages[0].message, 'Extra semicolon.', 'correct lint message')
+    t.equals(obj[0].errorCount, 1, 'successfully linted')
+    t.equals(obj[0].messages[0].message, 'Extra semicolon.', 'correct lint message')
+    t.end()
+  })
+})
+
+test('fix some text', (t) => {
+  client.post('/fix', { text: "console.log('woot');\n" }, (err, req, res, obj) => {
+    t.error(err, 'no error')
+    t.equals(obj[0].output, "console.log('woot')\n", 'correct fix output')
     t.end()
   })
 })


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[] Bug fix
[ ] New feature
[x] Other, please explain:

 - Update to `standard@17` and migrate to ESM. Also fix tests to work with new output object from lint/fix functions.
 - Note that this is a breaking change as the shape of the output object has changed for `/lint` and `/fix`. This means updating `standard-www` to accommodate these changes.

**What changes did you make? (Give an overview)**
 - switched from `require` to `import`
 - added `"type": "module"` to `package.json` as part of ESM migration
 - switched from `require`ing json/html files to `readFileSync`

**Which issue (if any) does this pull request address?**
 - no open issues, but keeping it fresh and up to date with latest `standard` version.

**Is there anything you'd like reviewers to focus on?**